### PR TITLE
Add support for additional Angular decorators

### DIFF
--- a/README.md
+++ b/README.md
@@ -38,6 +38,18 @@ configuration file.
   "directiveDecoratorOrder": [
     "selector",
     "providers"
+  ],
+  "pipeDecoratorOrder": [
+    "name",
+    "pure"
+  ],
+  "injectableDecoratorOrder": [
+    "providedIn",
+    "deps"
+  ],
+  "moduleDecoratorOrder": [
+    "imports",
+    "declarations"
   ]
 }
 ```
@@ -69,6 +81,12 @@ If you want to run the plugin only in some directories, configure
   properties in `@Component` decorators.
 - **`directiveDecoratorOrder`** – array that defines the desired order of
   properties in `@Directive` decorators.
+- **`pipeDecoratorOrder`** – array that defines the desired order of
+  properties in `@Pipe` decorators.
+- **`injectableDecoratorOrder`** – array that defines the desired order of
+  properties in `@Injectable` decorators.
+- **`moduleDecoratorOrder`** – array that defines the desired order of
+  properties in `@NgModule` decorators.
 - **`angularOrganizePatterns`** – optional list of glob patterns. The plugin
   only runs on files matching these patterns. If the array is empty the plugin
   runs for all files.

--- a/src/index.ts
+++ b/src/index.ts
@@ -23,6 +23,27 @@ export const options: {
     description: 'Order of attributes in Directive decorator.',
     default: [{value: []}],
   },
+  pipeDecoratorOrder: {
+    type: 'string',
+    category: 'Global',
+    array: true,
+    description: 'Order of attributes in Pipe decorator.',
+    default: [{value: []}],
+  },
+  injectableDecoratorOrder: {
+    type: 'string',
+    category: 'Global',
+    array: true,
+    description: 'Order of attributes in Injectable decorator.',
+    default: [{value: []}],
+  },
+  moduleDecoratorOrder: {
+    type: 'string',
+    category: 'Global',
+    array: true,
+    description: 'Order of attributes in NgModule decorator.',
+    default: [{value: []}],
+  },
   angularOrganizePatterns: {
     type: 'string',
     category: 'Global',

--- a/src/integration-tests/tests/injectable/extension
+++ b/src/integration-tests/tests/injectable/extension
@@ -1,0 +1,1 @@
+service.ts

--- a/src/integration-tests/tests/injectable/test-1/config.json
+++ b/src/integration-tests/tests/injectable/test-1/config.json
@@ -1,0 +1,6 @@
+{
+  "injectableDecoratorOrder": [
+    "providedIn",
+    "deps"
+  ]
+}

--- a/src/integration-tests/tests/injectable/test-1/expected.service.ts
+++ b/src/integration-tests/tests/injectable/test-1/expected.service.ts
@@ -1,0 +1,7 @@
+import { Injectable } from "@angular/core";
+
+@Injectable({
+  providedIn: "root",
+  deps: [],
+})
+export class MyService {}

--- a/src/integration-tests/tests/injectable/test-1/input.service.ts
+++ b/src/integration-tests/tests/injectable/test-1/input.service.ts
@@ -1,0 +1,7 @@
+import { Injectable } from "@angular/core";
+
+@Injectable({
+  deps: [],
+  providedIn: "root",
+})
+export class MyService {}

--- a/src/lib/transform-node.ts
+++ b/src/lib/transform-node.ts
@@ -48,6 +48,9 @@ function prettifyDecorator(decorator: Decorator, options: ParserOptions & Plugin
   const orderMap: Record<string, string[]> = {
     Component: options.componentDecoratorOrder,
     Directive: options.directiveDecoratorOrder,
+    Pipe: options.pipeDecoratorOrder,
+    Injectable: options.injectableDecoratorOrder,
+    NgModule: options.moduleDecoratorOrder,
   };
 
   const order = orderMap[decoratorName];

--- a/src/lib/types/plugin-options.type.ts
+++ b/src/lib/types/plugin-options.type.ts
@@ -1,5 +1,8 @@
 export type PluginOptions = {
   componentDecoratorOrder: string[];
   directiveDecoratorOrder: string[];
+  pipeDecoratorOrder: string[];
+  injectableDecoratorOrder: string[];
+  moduleDecoratorOrder: string[];
   angularOrganizePatterns: string[];
 };


### PR DESCRIPTION
## Summary
- support decorators for Pipe, Injectable and NgModule
- document new configuration options
- test Injectable decorator ordering

## Testing
- `npm test`